### PR TITLE
Remove extra line

### DIFF
--- a/doc_source/emr-what-is-emr.md
+++ b/doc_source/emr-what-is-emr.md
@@ -4,8 +4,6 @@
 
 If you are a first\-time user of Amazon EMR, we recommend that you begin by reading the following: 
 
-+ [What Is Amazon EMR?](#emr-what-is-emr) \(*this section*\) – This section provides an overview of Amazon EMR functionality and features\.
-
 + [Amazon EMR](https://aws.amazon.com/elasticmapreduce/) – This service page provides the Amazon EMR highlights, product details, and pricing information\.
 
 + [Getting Started: Analyzing Big Data with Amazon EMR](emr-gs.md) – This section provides a tutorial of using Amazon EMR to create a sample cluster and run a Hive script as a step\.


### PR DESCRIPTION
Seems a little redundant to have a docs page link to itself as recommended reading, but I could totally be overlooking something.

*Description of changes:*
Remove link to current page.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
