### PR TITLE
Fixed link to 5.8.0 known issues

### DIFF
--- a/doc_source/emr-cluster-application-history.md
+++ b/doc_source/emr-cluster-application-history.md
@@ -2,7 +2,7 @@
 
 Using Amazon EMR version 5\.8\.0 or later, you can view YARN application details using the **Application history** tab of a cluster's detail page in the console\. Using Amazon EMR application history makes it easier for you to troubleshoot and analyze active jobs and job history\. Instead of setting up and connecting to the master node to view open\-source troubleshooting UIs or sift through log files, you can quickly view application metrics and access relevant log files\.
 
-Application history is enabled automatically for all clusters that run YARN applications\. No special setup is required\. Amazon EMR keeps historical information for up to seven days after an application has completed\. Detailed application history is available only for Spark\. There are additional minor limitations in Amazon EMR version 5\.8\.0\. For more information, see [Known Issues](http://docs.aws.amazon.com/emr/latest/ReleaseGuide/emr-whatsnew.html#emr-580-known-issues) for version 5\.8\.0 in the *Amazon EMR Release Guide*\.
+Application history is enabled automatically for all clusters that run YARN applications\. No special setup is required\. Amazon EMR keeps historical information for up to seven days after an application has completed\. Detailed application history is available only for Spark\. There are additional minor limitations in Amazon EMR version 5\.8\.0\. For more information, see [Known Issues](https://docs.aws.amazon.com/emr/latest/ReleaseGuide/emr-whatsnew-history.html#emr-580-known-issues) for version 5\.8\.0 in the *Amazon EMR Release Guide*\.
 
 ## Example: View Job Details for a Spark Application<a name="app-history-spark-example"></a>
 


### PR DESCRIPTION
*Description of changes:*
A link was pointing to the release notes for the most recent release, whereas there's a page for historical releases.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
