### PR TITLE
Fix link to EncryptionMaterialsProvider interface

### DIFF
--- a/doc_source/emr-encryption-enable.md
+++ b/doc_source/emr-encryption-enable.md
@@ -38,7 +38,7 @@ The procedure below describes how to add the default EMR instance profile, `EMR_
 
 When using a security configuration, you must specify a different provider class name for local disk encryption and Amazon S3 encryption\.
 
-When you create a custom key provider, the application is expected to implement the [EncryptionMaterialsProvider interface](http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/s3/model/EncryptionMaterialsProvider.html), which is available in the AWS SDK for Java version 1\.11\.0 and later\. The implementation can use any strategy to provide encryption materials\. You may, for example, choose to provide static encryption materials or integrate with a more complex key management system\.
+When you create a custom key provider, the application is expected to implement the [EncryptionMaterialsProvider interface](https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/elasticmapreduce/spi/security/EncryptionMaterialsProvider.html), which is available in the AWS SDK for Java version 1\.11\.10 and later\. The implementation can use any strategy to provide encryption materials\. You may, for example, choose to provide static encryption materials or integrate with a more complex key management system\.
 
 The encryption algorithm used for custom encryption materials must be **AES/GCM/NoPadding**\.
 


### PR DESCRIPTION
The current link to the EncryptionMaterialsProvider interface is to the
S3 package. However, EMR is expecting it to be in the EMR package, so
updating the link to the documentation for the interface in the EMR SDK.
Additionally, git indicates this was only available in the SDK starting
in 1.11.10 (specifically introduced in
aws/aws-sdk-java@cafdbe14587d6d0d1d532d67906617d5adc8c721), so updating
the version reference.

*Issue #, if available:*

N/A

*Description of changes:*

I wrote a provider that extended `com.amazonaws.services.s3.model.EncryptionMaterialsProvider` as implied by the existing documentation, and it errored out with:

> 2019-05-01 04:53:06,701 ERROR main: Failed to load CustomProvider: 
java.lang.ClassCastException: com.myorg.MyEncryptionMaterialsProvider cannot be cast to com.amazonaws.services.elasticmapreduce.spi.security.EncryptionMaterialsProvider

which indicates the link was to the wrong class. This fixes the link.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.