### PR TITLE
Fix emr-autoscaling json file example

### DIFF
--- a/emr-automatic-scaling.md
+++ b/emr-automatic-scaling.md
@@ -157,46 +157,45 @@ aws emr put-auto-scaling-policy --cluster-id j-1EKZ3TYEVF1S2 --instance-group-id
 The contents of the `autoscaleconfig.json` file, which defines the same scale\-out rule as shown in the previous example, is shown below\.
 
 ```
-"AutoScalingPolicy":
-    {
-     "Constraints":
-      {
-       "MinCapacity": 2,
-       "MaxCapacity": 10
-      },
-     "Rules":
-     [
-      {
-       "Name": "Default-scale-out",
-       "Description": "Replicates the default scale-out rule in the console for YARN memory.",
-       "Action":{
-        "SimpleScalingPolicyConfiguration":{
-          "AdjustmentType": "CHANGE_IN_CAPACITY",
-          "ScalingAdjustment": 1,
-          "CoolDown": 300
-        }
-       },
-       "Trigger":{
-        "CloudWatchAlarmDefinition":{
-          "ComparisonOperator": "LESS_THAN",
-          "EvaluationPeriods": 1,
-          "MetricName": "YARNMemoryAvailablePercentage",
-          "Namespace": "AWS/ElasticMapReduce",
-          "Period": 300,
-          "Threshold": 15,
-          "Statistic": "AVERAGE",
-          "Unit": "PERCENT",
-          "Dimensions":[
-             {
-               "Key" : "JobFlowId",
-               "Value" : "${emr.clusterId}"
-             }
-          ]
-        }
-       }
-      }
-     ]
+{
+ "Constraints":
+  {
+   "MinCapacity": 2,
+   "MaxCapacity": 10
+  },
+ "Rules":
+ [
+  {
+   "Name": "Default-scale-out",
+   "Description": "Replicates the default scale-out rule in the console for YARN memory.",
+   "Action":{
+    "SimpleScalingPolicyConfiguration":{
+      "AdjustmentType": "CHANGE_IN_CAPACITY",
+      "ScalingAdjustment": 1,
+      "CoolDown": 300
+    }
+   },
+   "Trigger":{
+    "CloudWatchAlarmDefinition":{
+      "ComparisonOperator": "LESS_THAN",
+      "EvaluationPeriods": 1,
+      "MetricName": "YARNMemoryAvailablePercentage",
+      "Namespace": "AWS/ElasticMapReduce",
+      "Period": 300,
+      "Threshold": 15,
+      "Statistic": "AVERAGE",
+      "Unit": "PERCENT",
+      "Dimensions":[
+         {
+           "Key" : "JobFlowId",
+           "Value" : "${emr.clusterId}"
+         }
+      ]
+    }
    }
+  }
+ ]
+}
 ```
 
 ### Removing an Automatic Scaling Policy from an Instance Group<a name="emr-autoscale-cli-removepolicy"></a>


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:* The emr-automatic-scaling documentation provides an example of file autoscaleconfig.json that can be used to modify the autoscaling policy of an existing instance group. However the example gives a json parsing error. 
I've fixed the error removing the first line

`"AutoScalingPolicy":`

from the example. I've tested it with aws-cli/1.16.262 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
