### PR TITLE
fix grammatical error

### DIFF
--- a/doc_source/emr-plan-debugging.md
+++ b/doc_source/emr-plan-debugging.md
@@ -151,6 +151,6 @@ Enable debugging using the following StepConfig:
 
 Amazon EMR release 4\.1 or later supports debugging in all regions\.
 
-The Amazon EMR creates an Amazon SQS queue to process debugging data\. Message charges may apply\. However, Amazon SQS does have Free Tier of up to 1,000,000 requests available\. For more information, see the [Amazon SQS detail page](https://aws.amazon.com/sqs)\.
+Amazon EMR creates an Amazon SQS queue to process debugging data\. Message charges may apply\. However, Amazon SQS does have Free Tier of up to 1,000,000 requests available\. For more information, see the [Amazon SQS detail page](https://aws.amazon.com/sqs)\.
 
 Debugging requires the use of roles; your service role and instance profile must allow you to use all Amazon SQS API operations\. If your roles are attached to Amazon EMR managed policies, you do not need to do anything to modify your roles\. If you have custom roles, you need to add `sqs:*` permissions\. For more information, see [Configure IAM Service Roles for Amazon EMR Permissions to AWS Services and Resources](emr-iam-roles.md)\.


### PR DESCRIPTION
I've resolved a minor grammatical error by removing an errant "the." Amazon EMR is a proper noun and needs no article, except when used as a modifier for a generic noun (e.g. the EMR service, the EMR console).