### PR TITLE
Livy is hosted on :8999, not :8998

### DIFF
--- a/emr-web-interfaces.md
+++ b/emr-web-interfaces.md
@@ -18,6 +18,7 @@ To access web interfaces, you must edit the security groups associated with mast
 | Hadoop HDFS NameNode | http://master\-public\-dns\-name:50070/ | 
 | Hadoop HDFS DataNode | http://coretask\-public\-dns\-name:50075/ | 
 | Spark HistoryServer | http://master\-public\-dns\-name:18080/ | 
+| Livy | https://master\-public\-dns\-name:8998/ | 
 | Zeppelin | http://master\-public\-dns\-name:8890/ | 
 | Hue | http://master\-public\-dns\-name:8888/ | 
 | Ganglia | http://master\-public\-dns\-name/ganglia/ | 


### PR DESCRIPTION
*Issue #, if available:*
N/A
*Description of changes:*
Lists Livy port as 8999.

The current documentation which is live at https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-web-interfaces.html
states that Livy is hosted on :8999, but it seems to be on :8998 when I ssh into `emr-5.29.0` clusters created with the
Livy application passed in during cluster creation.


Indeed, by submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
