### PR TITLE
Okta SAML Attribute url correction

### DIFF
--- a/doc_source/emr-lf-idp.md
+++ b/doc_source/emr-lf-idp.md
@@ -82,6 +82,6 @@ To enable federated access to Lake Formation, customize the following steps:
 
      Value: `user_alias`
 
-  1. Name: `https://glue.amazon.com/SAML/Attributes/UserName`
+  1. Name: `https://lakeformation.amazon.com/SAML/Attributes/Username`
 
      Value: `user_alias`


### PR DESCRIPTION
Updated SAML attribute name for OKTA from https://glue.amazon.com/SAML/Attributes/UserName To  https://lakeformation.amazon.com/SAML/Attributes/Username.
Reference https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-lf-federation.html .

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
