### PR TITLE
String Not Equals Condition

### DIFF
--- a/doc_source/emr-fine-grained-cluster-access.md
+++ b/doc_source/emr-fine-grained-cluster-access.md
@@ -85,7 +85,7 @@ As in the preceding example, the following example policy looks for the same mat
 21. }
 ```
 
-In the following example, the EMR actions that allow the addition and removal of tags is combined with a `StringNotEquals` operator specifying the `dev` tag we've seen in earlier examples\. The effect of this policy is to deny a user the permission to add or remove any tags on EMR clusters that are tagged with a `department` tag that contains the `dev` value\.
+In the following example, the EMR actions that allow the addition and removal of tags is combined with a `StringNotEquals` operator specifying the `dev` tag we've seen in earlier examples\. The effect of this policy is to deny a user the permission to add or remove any tags on EMR clusters that are tagged with a `department` tag that does not matches the `dev` value\.
 
 ```
 {


### PR DESCRIPTION
This policy is to deny permission to Add/Remove Tags on the EMR Clusters with the Department Tag Values does not matches the 'dev' value.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
