### PR TITLE
Slight rewording to make the statement on EMR support for private subnets clearer

### DIFF
--- a/doc_source/emr-plan-vpc-subnet.md
+++ b/doc_source/emr-plan-vpc-subnet.md
@@ -14,7 +14,7 @@ VPC offers the following capabilities:
 You can launch EMR clusters in both public and private VPC subnets\. This means you do not need internet connectivity to run an EMR cluster; however, you may need to configure network address translation \(NAT\) and VPN gateways to access services or resources located outside of the VPC, for example in a corporate intranet or public AWS service endpoints like AWS Key Management Service\.
 
 **Important**  
-Amazon EMR only supports launching clusters in private subnets in releases 4\.2 or greater\.
+Amazon EMR supports launching clusters in private subnets only in releases 4\.2 or greater\.
 
 For more information about Amazon VPC, see the [Amazon VPC User Guide](https://docs.aws.amazon.com/vpc/latest/userguide/)\.
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

In the previous form, one could interpret the statement as meaning releases 4.2 and greater only support private subnets, which seems to contradict the preceding paragraph. I had to stare at it for sometime to get the actual meaning. Modified the statement slightly to make the intended meaning clearer.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
